### PR TITLE
Postfix param for 'words' filter.

### DIFF
--- a/src/truncate.js
+++ b/src/truncate.js
@@ -35,13 +35,14 @@ angular.module('truncate', [])
         };
     })
     .filter('words', function () {
-        return function (input, words) {
+        return function (input, words, postfix) {
             if (isNaN(words)) return input;
             if (words <= 0) return '';
+            if (typeof postfix === 'undefined') postfix = '…';
             if (input) {
                 var inputWords = input.split(/\s+/);
                 if (inputWords.length > words) {
-                    input = inputWords.slice(0, words).join(' ') + '…';
+                    input = inputWords.slice(0, words).join(' ') + postfix;
                 }
             }
             return input;

--- a/test/filtersSpec.js
+++ b/test/filtersSpec.js
@@ -93,6 +93,18 @@ describe('truncate', function () {
             expect(wordFilter('abc def ghhi jkl mno pqr stu vw xyz', 25)).toEqual('abc def ghhi jkl mno pqr stu vw xyz');
         });
 
+        it('should trim these down without ellipsis postfix', function () {
+            expect(wordFilter('abc def ghhi jkl mno pqr stu vw xyz', 5, '')).toEqual('abc def ghhi jkl mno');
+        });
+
+        it('should trim these down with specific postfix', function () {
+            expect(wordFilter('abc def ghhi jkl mno pqr stu vw xyz', 5, '...')).toEqual('abc def ghhi jkl mno...');
+        });
+
+        it('should trim these down with blank postfix', function () {
+            expect(wordFilter('abc def ghhi jkl mno pqr stu vw xyz', 5, '')).toEqual('abc def ghhi jkl mno');
+        });
+
     });
 
     describe('splitcharacters', function () {


### PR DESCRIPTION
Adding `postfix` param for words filter suggested by @bernardolm in https://github.com/sparkalow/angular-truncate/pull/29
